### PR TITLE
feat(api): export {tokenize} function

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    "es2015"
+  ],
+  "env": {
+    "development": {
+      "plugins": [
+        "babel-plugin-espower"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -19,14 +19,13 @@ Export two API.
 - `kuromojin as default` return `Promise` that is resolved with analyzed text.
 
 ```js
-import kuromojin from "kuromojin";
-import {getTokenizer} from "kuromojin";
+import {tokenize, getTokenizer} from "kuromojin";
 
 getTokenizer().then(tokenizer => {
     // kuromoji.js's `tokenizer` instance
 });
 
-kuromojin(text).then(results => {
+tokenize(text).then(results => {
     console.log(results)
     /*
     [ {
@@ -46,6 +45,21 @@ kuromojin(text).then(results => {
       } ]
     */
 });
+```
+
+### Note: backward compatibility for <= 1.1.0
+
+kuromojin v1.1.0 export `tokenize` as default function
+
+```js
+import kuromojin from "kuromojin";
+// kuromojin === tokenize
+```
+
+Recommended use `import {tokenize} from "kuromojin"` instead of it
+
+```js
+import {tokenize} from "kuromojin";
 ```
 
 ## Tests

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "description": "Provide a high level wrapper for kuromoji.js",
   "main": "lib/kuromojin.js",
   "files": [
-    "lib",
-    "src"
+    "lib/",
+    "src/"
   ],
   "directories": {
     "test": "test"
@@ -36,8 +36,10 @@
     "kuromoji": "^0.0.5"
   },
   "devDependencies": {
-    "babel": "^5.8.34",
-    "espower-babel": "^3.3.0",
+    "babel-cli": "^6.6.5",
+    "babel-plugin-espower": "^2.1.2",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-register": "^6.7.2",
     "mocha": "^2.3.3",
     "power-assert": "^1.1.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+// LICENSE : MIT
+"use strict";
+import {tokenize, getTokenizer} from "./kuromojin";
+module.exports = tokenize;
+module.exports.tokenize = tokenize;
+module.exports.getTokenizer = getTokenizer;

--- a/src/kuromojin.js
+++ b/src/kuromojin.js
@@ -1,8 +1,9 @@
 // LICENSE : MIT
 "use strict";
-import kuromoji from "kuromoji";
-import path from "path";
+const path = require("path");
+const kuromoji = require("kuromoji");
 import Deferred from "./Deferred";
+
 const kuromojiDir = require.resolve("kuromoji");
 const options = {dicPath: path.join(kuromojiDir, "../../dict") + "/"};
 const deferred = new Deferred();
@@ -31,6 +32,5 @@ export function getTokenizer() {
 export function tokenize(text) {
     return getTokenizer().then(tokenizer => {
         return tokenizer.tokenize(text);
-    })
+    });
 }
-export default tokenize;

--- a/test/kuromojin-test.js
+++ b/test/kuromojin-test.js
@@ -1,8 +1,9 @@
 // LICENSE : MIT
 "use strict";
 import assert from "power-assert";
-import kuromojin from "../src/kuromojin";
-import {getTokenizer} from "../src/kuromojin";
+// it is compatible check for <= 1.1.0
+import defaultFunction from "../src";
+import {getTokenizer, tokenize} from "../src";
 describe("kuromojin", function () {
     context("many access at a time", function () {
         it("should return a.promise", function () {
@@ -17,11 +18,23 @@ describe("kuromojin", function () {
             });
         });
     });
-    context("kuromojin", function () {
+    context("tokenize", function () {
+        it("is alias to default", function () {
+            var data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+            var promises = data.map(num => {
+                return defaultFunction(String(num));
+            });
+            return Promise.all(promises).then(texts => {
+                texts.forEach((results, index) => {
+                    let firstNode = results[0];
+                    assert.equal(firstNode.surface_form, String(index));
+                });
+            });
+        });
         it("should return a.promise that resolve analyzed text", function () {
             var data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
             var promises = data.map(num => {
-                return kuromojin(String(num));
+                return tokenize(String(num));
             });
             return Promise.all(promises).then(texts => {
                 texts.forEach((results, index) => {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:espower-babel/guess
+--compilers js:babel-register


### PR DESCRIPTION
Note: backward compatibility for <= 1.1.0

kuromojin v1.1.0 export `tokenize` as default function

``` js
import kuromojin from "kuromojin";
// kuromojin === tokenize
```

Recommended use `import {tokenize} from "kuromojin"` instead of it

``` js
import {tokenize} from "kuromojin";
```
