### PR TITLE
Make tokenize return type readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Provide a high level wrapper for [kuromoji.js](https://github.com/takuyaa/kuromo
 Export two API.
 
 - `getTokenizer()` return `Promise` that is resolved with kuromoji.js's `tokenizer` instance.
-- `tokenize()` return `Promise` that is resolved with analyzed tokens.
+- `tokenize()` return `Promise` that is resolved with analyzed tokens. 
+- The array and objects returned by `tokenize()` are read-only to ensure immutability and prevent modification of cached data.
 
 ```js
 import {tokenize, getTokenizer} from "kuromojin";

--- a/src/kuromojin.ts
+++ b/src/kuromojin.ts
@@ -96,7 +96,7 @@ export function getTokenizer(options: getTokenizerOption = { dicPath: getNodeMod
     return deferred.promise;
 }
 
-export function tokenize(text: string, options?: getTokenizerOption): Promise<KuromojiToken[]> {
+export function tokenize(text: string, options?: getTokenizerOption): Promise<Readonly<Readonly<KuromojiToken>[]>> {
     return getTokenizer(options).then((tokenizer) => {
         if (options?.noCacheTokenize) {
             return tokenizer.tokenizeForSentence(text);


### PR DESCRIPTION
This relates to #15. Sadly i did not get to this earlier. I also updated the readme, let me know if this is what you had in mind.